### PR TITLE
调整ZoneLocator继承结构，AbstractZoneLocator.doGet方法移动到HttpUtils

### DIFF
--- a/microsphere-multiactive-spring-cloud/src/main/java/io/microsphere/multiple/active/zone/AbstractZoneLocator.java
+++ b/microsphere-multiactive-spring-cloud/src/main/java/io/microsphere/multiple/active/zone/AbstractZoneLocator.java
@@ -4,6 +4,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.BeanNameAware;
 import org.springframework.context.EnvironmentAware;
+import org.springframework.core.Ordered;
 import org.springframework.core.env.Environment;
 import org.springframework.util.StreamUtils;
 import org.springframework.util.StringUtils;
@@ -24,15 +25,13 @@ import static io.microsphere.multiple.active.zone.ZoneConstants.LOCATOR_TIMEOUT_
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy<a/>
  * @since 1.0.0
  */
-public abstract class AbstractZoneLocator implements ZoneLocator, BeanNameAware, EnvironmentAware {
+public abstract class AbstractZoneLocator implements ZoneLocator, BeanNameAware, Ordered {
 
     protected final Logger logger = LoggerFactory.getLogger(getClass());
 
     protected String beanName;
 
     protected int order;
-
-    private int timeout = DEFAULT_TIMEOUT;
 
     public AbstractZoneLocator(int order) {
         setOrder(order);
@@ -41,11 +40,6 @@ public abstract class AbstractZoneLocator implements ZoneLocator, BeanNameAware,
     @Override
     public final void setBeanName(String beanName) {
         this.beanName = beanName;
-    }
-
-    @Override
-    public void setEnvironment(Environment environment) {
-        this.timeout = environment.getProperty(LOCATOR_TIMEOUT_PROPERTY_NAME, int.class, DEFAULT_TIMEOUT);
     }
 
     @Override
@@ -63,27 +57,4 @@ public abstract class AbstractZoneLocator implements ZoneLocator, BeanNameAware,
         return "ZoneLocator{" + "beanName='" + beanName + '\'' + ", order=" + order + '}';
     }
 
-    protected String doGet(String url) throws IOException {
-        String content = null;
-        if (StringUtils.hasText(url)) {
-            URLConnection urlConnection = new URL(url).openConnection();
-            if (urlConnection instanceof HttpURLConnection) {
-                HttpURLConnection httpURLConnection = (HttpURLConnection) urlConnection;
-                int timeout = getTimeout();
-                urlConnection.setConnectTimeout(timeout);
-                urlConnection.setReadTimeout(timeout);
-                try (InputStream inputStream = httpURLConnection.getInputStream()) {
-                    content = StreamUtils.copyToString(inputStream, StandardCharsets.UTF_8);
-                    logger.info("The response of Availability Zone Endpoint[URI : '{}'] : {}", url, content);
-                }finally {
-                    httpURLConnection.disconnect();
-                }
-            }
-        }
-        return content;
-    }
-
-    protected final int getTimeout() {
-        return timeout;
-    }
 }

--- a/microsphere-multiactive-spring-cloud/src/main/java/io/microsphere/multiple/active/zone/CompositeZoneLocator.java
+++ b/microsphere-multiactive-spring-cloud/src/main/java/io/microsphere/multiple/active/zone/CompositeZoneLocator.java
@@ -15,23 +15,20 @@ import static io.microsphere.multiple.active.zone.ZoneConstants.DEFAULT_LOCATOR_
 import static io.microsphere.multiple.active.zone.ZoneConstants.LOCATOR_FAST_FAIL_PROPERTY_NAME;
 
 /**
- * The composite {@link ZoneLocator}
+ * The composition of {@link ZoneLocator} list.
  *
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy<a/>
  * @since 1.0.0
  */
-public class CompositeZoneLocator extends AbstractZoneLocator {
+public class CompositeZoneLocator implements ZoneLocator {
 
     private static final Logger logger = LoggerFactory.getLogger(CompositeZoneLocator.class);
-
-    public static final int DEFAULT_ORDER = 0;
 
     private final List<ZoneLocator> zoneLocators;
 
     private volatile String zone;
 
     public CompositeZoneLocator(List<ZoneLocator> zoneLocators) {
-        super(DEFAULT_ORDER);
         Assert.notNull(zoneLocators, "The argument 'zoneLocators' must not be null!");
         this.zoneLocators = new ArrayList<>(zoneLocators);
         AnnotationAwareOrderComparator.sort(this.zoneLocators);
@@ -39,7 +36,13 @@ public class CompositeZoneLocator extends AbstractZoneLocator {
 
     @Override
     public boolean supports(Environment environment) {
-        return true;
+        // Supported when at least one object supports.
+        for (ZoneLocator zoneLocator : zoneLocators) {
+            if (zoneLocator.supports(environment)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override
@@ -86,7 +89,7 @@ public class CompositeZoneLocator extends AbstractZoneLocator {
         }
 
         if (zone == null) {
-            logger.warn("The zone can't be located by anyone of zoneLocators : ", zoneLocators);
+            logger.warn("The zone can't be located by anyone of zoneLocators : {}", zoneLocators);
         }
 
         this.zone = zone;
@@ -102,6 +105,6 @@ public class CompositeZoneLocator extends AbstractZoneLocator {
 
     @Override
     public String toString() {
-        return "CompositeZoneLocator{" + "beanName='" + beanName + '\'' + ", zoneLocators=" + zoneLocators + '}';
+        return "CompositeZoneLocator{" + "zoneLocators=" + zoneLocators + ", zone=" + zone + '}';
     }
 }

--- a/microsphere-multiactive-spring-cloud/src/main/java/io/microsphere/multiple/active/zone/HttpUtils.java
+++ b/microsphere-multiactive-spring-cloud/src/main/java/io/microsphere/multiple/active/zone/HttpUtils.java
@@ -1,0 +1,51 @@
+package io.microsphere.multiple.active.zone;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.StreamUtils;
+import org.springframework.util.StringUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * The utilities class for simple http request.
+ *
+ * @author <a href="mailto:warlklown@gmail.com">Warlklown<a/>
+ * @since 1.0.0
+ */
+public abstract class HttpUtils {
+
+    private static final Logger logger = LoggerFactory.getLogger(HttpUtils.class);
+
+    /**
+     * Retrieve a representation by doing a GET on the specified URL. The response (if any) is returned.
+     *
+     * @param url the URL
+     * @param timeout timeout – an int that specifies the connect timeout value in milliseconds
+     * @return The response context
+     * @throws IOException
+     */
+    public static String doGet(String url, int timeout) throws IOException {
+        String content = null;
+        if (StringUtils.hasText(url)) {
+            URLConnection urlConnection = new URL(url).openConnection();
+            if (urlConnection instanceof HttpURLConnection) {
+                HttpURLConnection httpURLConnection = (HttpURLConnection) urlConnection;
+                urlConnection.setConnectTimeout(timeout);
+                urlConnection.setReadTimeout(timeout);
+                try (InputStream inputStream = httpURLConnection.getInputStream()) {
+                    content = StreamUtils.copyToString(inputStream, StandardCharsets.UTF_8);
+                    logger.info("The response of Availability Zone Endpoint[URI : '{}'] : {}", url, content);
+                } finally {
+                    httpURLConnection.disconnect();
+                }
+            }
+        }
+        return content;
+    }
+}

--- a/microsphere-multiactive-spring-cloud/src/main/java/io/microsphere/multiple/active/zone/HttpUtils.java
+++ b/microsphere-multiactive-spring-cloud/src/main/java/io/microsphere/multiple/active/zone/HttpUtils.java
@@ -15,7 +15,7 @@ import java.nio.charset.StandardCharsets;
 /**
  * The utilities class for simple http request.
  *
- * @author <a href="mailto:warlklown@gmail.com">Warlklown<a/>
+ * @author <a href="mailto:warlklown@gmail.com">Walklown<a/>
  * @since 1.0.0
  */
 public abstract class HttpUtils {

--- a/microsphere-multiactive-spring-cloud/src/main/java/io/microsphere/multiple/active/zone/ZoneLocator.java
+++ b/microsphere-multiactive-spring-cloud/src/main/java/io/microsphere/multiple/active/zone/ZoneLocator.java
@@ -1,6 +1,5 @@
 package io.microsphere.multiple.active.zone;
 
-import org.springframework.core.Ordered;
 import org.springframework.core.env.Environment;
 
 /**
@@ -9,7 +8,7 @@ import org.springframework.core.env.Environment;
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy<a/>
  * @since 1.0.0
  */
-public interface ZoneLocator extends Ordered {
+public interface ZoneLocator {
 
     /**
      * Current {@link ZoneLocator} supports or not ?


### PR DESCRIPTION
1、调整ZoneLocator继承结构，考虑到AbstractZoneLocator主要用于为ZoneLocator的实现类提供抽象能力，而CompositeZoneLocator是一个组合适配器，并非ZoneLocator的真实实现，因此CompositeZoneLocator不再继承AbstractZoneLocator。
2、AbstractZoneLocator.doGet方法并非ZoneLocator的实现类的抽象能力之一，只是一个简单的HTTP请求封装方法，因此移动到HttpUtils。
3、ZoneLocator的排序能力是ZoneLocator的实现类的通用可选抽象能力之一，并非ZoneLocator本身的必要实现，因此移动到AbstractZoneLocator进行实现（后续可考虑提供默认值）。