### PR TITLE
Bump microsphere-spring-cloud version to 0.1.16 and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ pom.xml:
 
 | **Branches** | **Purpose**                                      | **Latest Version** |
 |--------------|--------------------------------------------------|--------------------|
-| **main**     | Compatible with Spring Cloud 2022.0.x - 2025.0.x | `0.2.4`            |
-| **1.x**      | Compatible with Spring Cloud Hoxton - 2021.0.x   | `0.1.4`            |
+| **main**     | Compatible with Spring Cloud 2022.0.x - 2025.0.x | `0.2.5`            |
+| **1.x**      | Compatible with Spring Cloud Hoxton - 2021.0.x   | `0.1.5`            |
 
 ## Building from Source
 

--- a/microsphere-multiactive-parent/pom.xml
+++ b/microsphere-multiactive-parent/pom.xml
@@ -20,7 +20,7 @@
 
     <properties>
         <!-- BOM versions -->
-        <microsphere-spring-cloud.version>0.1.15</microsphere-spring-cloud.version>
+        <microsphere-spring-cloud.version>0.1.16</microsphere-spring-cloud.version>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.microsphere-projects</groupId>
         <artifactId>microsphere-spring-cloud-parent</artifactId>
-        <version>0.1.15</version>
+        <version>0.1.16</version>
     </parent>
 
     <groupId>io.github.microsphere-projects</groupId>


### PR DESCRIPTION
This pull request updates the project to use the latest version of the `microsphere-spring-cloud` dependency and increments the documented version numbers to reflect the new release. These changes ensure consistency across the project configuration and documentation.

Dependency and version updates:

* Updated the parent project version in `pom.xml` from `0.1.15` to `0.1.16` to use the latest release of the parent dependency.
* Updated the `microsphere-spring-cloud.version` property in `microsphere-multiactive-parent/pom.xml` from `0.1.15` to `0.1.16`.

Documentation updates:

* Updated the version numbers in the branch compatibility table in `README.md` to reflect the new releases: `main` branch from `0.2.4` to `0.2.5`, and `1.x` branch from `0.1.4` to `0.1.5`.