### PR TITLE
Bump branch versions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ pom.xml:
 
 | **Branches** | **Purpose**                                      | **Latest Version** |
 |--------------|--------------------------------------------------|--------------------|
-| **main**     | Compatible with Spring Cloud 2022.0.x - 2025.0.x | `0.2.5`            |
-| **1.x**      | Compatible with Spring Cloud Hoxton - 2021.0.x   | `0.1.5`            |
+| **main**     | Compatible with Spring Cloud 2022.0.x - 2025.0.x | `0.2.6`            |
+| **1.x**      | Compatible with Spring Cloud Hoxton - 2021.0.x   | `0.1.6`            |
 
 ## Building from Source
 


### PR DESCRIPTION
Update README table to reflect new latest versions for branches: main updated to 0.2.6 and 1.x updated to 0.1.6. Documentation-only change to keep release info current.